### PR TITLE
add buster distribution

### DIFF
--- a/wazo_dist/main.py
+++ b/wazo_dist/main.py
@@ -16,6 +16,9 @@ NAMED_DISTRIBUTIONS = [
     'wazo-rc-stretch',
     'phoenix-stretch',
     'pelican-stretch',
+    'wazo-dev-buster',
+    'wazo-rc-buster',
+    'pelican-buster',
 ]
 DEB_SOURCE_CONTENT = """
 # {distrib}


### PR DESCRIPTION
why: even if autodetect is not the preferred way to use wazo-dist, it's
still supported and we should avoid to add confusion with half working
solution