### PR TITLE
add python3-setuptools dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,8 @@ Package: wazo-dist
 Architecture: all
 Depends:
   ${python3:Depends},
-  ${misc:Depends}
+  ${misc:Depends},
+  python3-setuptools
 Replaces: xivo-dist
 Conflicts: xivo-dist
 Provides: xivo-dist


### PR DESCRIPTION
load_entry_point is provided by setuptools