### PR TITLE
add upcoming Bullseye distribution

### DIFF
--- a/wazo_dist/main.py
+++ b/wazo_dist/main.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -19,6 +19,9 @@ NAMED_DISTRIBUTIONS = [
     'wazo-dev-buster',
     'wazo-rc-buster',
     'pelican-buster',
+    'wazo-dev-bullseye',
+    'wazo-rc-bullseye',
+    'pelican-bullseye',
 ]
 DEB_SOURCE_CONTENT = """
 # {distrib}


### PR DESCRIPTION
why: even if they don't exist now, adding them will avoid to backport
them when releasing bullseye